### PR TITLE
Output-file identical check

### DIFF
--- a/checkers/netcdf_identical_check.sh
+++ b/checkers/netcdf_identical_check.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# COSMO TECHNICAL TESTSUITE
+#
+# This script checks whether the content of NetCDF files is identical
+
+
+# check environment variables
+RUNDIR=${TS_RUNDIR}
+REFOUTDIR=${TS_REFOUTDIR}
+VERBOSE=${TS_VERBOSE}
+
+if [ -z "${VERBOSE}" ] ; then
+  echo "Environment variable TS_VERBOSE is not set" 1>&1
+  exit 20 # FAIL
+fi
+
+if [ -z "${RUNDIR}" ] ; then
+  echo "Environment variable TS_RUNDIR is not set" 1>&1
+  exit 20 # FAIL
+fi
+if [ ! -d "${RUNDIR}" ] ; then
+  echo "Directory TS_RUNDIR=${RUNDIR} does not exist" 1>&1
+  exit 20 # FAIL
+fi
+
+if [ -z "${REFOUTDIR}" ] ; then
+  echo "Environment variable TS_REFOUTDIR is not set" 1>&1
+  exit 20 # FAIL
+fi
+if [ ! -d "${REFOUTDIR}" ] ; then
+  echo "Directory TS_REFOUTDIR=${REFOUTDIR} does not exist" 1>&1
+  exit 20 # FAIL
+fi
+
+FILELIST=$(ls -1 ${RUNDIR}/output/l[bf]f*00.nc 2>/dev/null)
+if [ $? -ne 0 ] ; then
+  echo "No netCDF output file found in " ${RUNDIR}  1>&1
+  exit 20 # FAIL
+fi
+
+FILELIST=$(ls -1 ${REFOUTDIR}/output/l[bf]f*00.nc 2>/dev/null)
+if [ $? -ne 0 ] ; then
+  echo "No netCDF output file found in " ${REFOUTDIR}  1>&1
+  exit 20 # FAIL
+fi
+
+for f in `ls ${RUNDIR}/output/*.nc | xargs -n 1 basename` ; do
+  DIFF=$(cdo -s diff ${RUNDIR}/output/${f} ${REFOUTDIR}/output/${f})
+  if [ ! -z $DIFF ] ; then
+    echo $DIFF  1>&1
+    exit 20 # FAIL
+  fi
+done
+
+# goodbye
+exit 0 # MATCH

--- a/checkers/netcdf_identical_check.sh
+++ b/checkers/netcdf_identical_check.sh
@@ -45,7 +45,8 @@ if [ $? -ne 0 ] ; then
   exit 20 # FAIL
 fi
 
-for f in `ls ${RUNDIR}/output/*.nc | xargs -n 1 basename` ; do
+REGEX='^.*lff[fd][0-9]+[a-zA-Z]{0,1}(.nc){0,1}' #Find NetCDF and GRIB files, based on name
+for f in `find ${RUNDIR}/output -regextype posix-extended -regex $REGEX` ; do
   DIFF=$(cdo -s diffv ${RUNDIR}/output/${f} ${REFOUTDIR}/output/${f})
   if [ ! -z $DIFF ] ; then
     echo $DIFF  1>&1

--- a/checkers/netcdf_identical_check.sh
+++ b/checkers/netcdf_identical_check.sh
@@ -46,7 +46,7 @@ if [ $? -ne 0 ] ; then
 fi
 
 for f in `ls ${RUNDIR}/output/*.nc | xargs -n 1 basename` ; do
-  DIFF=$(cdo -s diff ${RUNDIR}/output/${f} ${REFOUTDIR}/output/${f})
+  DIFF=$(cdo -s diffv ${RUNDIR}/output/${f} ${REFOUTDIR}/output/${f})
   if [ ! -z $DIFF ] ; then
     echo $DIFF  1>&1
     exit 20 # FAIL

--- a/checkers/output_files_identical_check.sh
+++ b/checkers/output_files_identical_check.sh
@@ -2,7 +2,8 @@
 
 # COSMO TECHNICAL TESTSUITE
 #
-# This script checks whether the content of NetCDF files is identical
+# This script checks whether the content of NetCDF/GRIB files is identical
+# David Leutwyler, October 2017
 
 
 # check environment variables

--- a/checkers/output_files_identical_check.sh
+++ b/checkers/output_files_identical_check.sh
@@ -2,9 +2,17 @@
 
 # COSMO TECHNICAL TESTSUITE
 #
+# Software dependencies:
+#
+# - to be run from the bourne shell
+# - CDO (Climate Data Operators, <http://code.zmaw.de/projects/cdo>) 
+#   Version 1.5 needed for GRIB files!
+#   CDO needs to be built with GRIB and/or netCDF support
 # This script checks whether the content of NetCDF/GRIB files is identical
 # David Leutwyler, October 2017
 
+#Software
+cdo=/apps/dom/UES/jenkins/6.0.UP04/gpu/easybuild/software/CDO/1.9.0-CrayGNU-17.08/bin/cdo
 
 # check environment variables
 RUNDIR=${TS_RUNDIR}


### PR DESCRIPTION
Add a simple cdo-based identity-checker for GRIB and NetCDF output files. It can, for instance, be used to test synchronous vs. asynchronous output.

@kosterried @ofuhrer 