### PR TITLE
fix grib existence checker

### DIFF
--- a/checkers/existence_grib_out.sh
+++ b/checkers/existence_grib_out.sh
@@ -62,7 +62,7 @@ FILE=$(find ${RUNDIR}/output -regex "${REGEX}")
 # determine number of IO processors
 nprocio=0
 if [ -s "${RUNDIR}/${TS_CONFIG_NL}" ] ; then
-  nprocio=`grep nprocio ${RUNDIR}/${TS_CONFIG_NL} | awk '{print \$2}'`
+  nprocio=`grep -w nprocio ${RUNDIR}/${TS_CONFIG_NL} | awk '{print \$2}'`
 fi
 
 # cat together files if parallel grib I/O was used

--- a/testsuite.py
+++ b/testsuite.py
@@ -29,8 +29,8 @@ from default_values import DefaultValues
 __author__     = "Nicolo Lardelli, Xavier Lapillonne, Oliver Fuhrer, Santiago Moreno"
 __copyright__  = "Copyright 2012-2018, COSMO Consortium"
 __license__    = "MIT"
-__version__    = "2.2.4"
-__date__       = "8.11.2018"
+__version__    = "2.2.5"
+__date__       = "13.11.2018"
 __email__      = "cosmo-wg6@cosmo.org"
 __maintainer__ = "xavier.lapillonne@meteoswiss.ch"
 


### PR DESCRIPTION
The checker was creating an error message because it was looking
for nprocio, but the latest version of cosmo also has a
nprocio_radar
Increase version number